### PR TITLE
Use new Danger 3.2.0 features

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -4,17 +4,18 @@ copyright_header = "////Wire//Copyright(C)2016WireSwissGmbH////Thisprogramisfree
 
 touched = git.added_files | git.modified_files
 paths = touched.select { |f| f.end_with? ".h", ".m", ".swift", ".mm" }
+
 paths.each do |p|
   next unless File.exist?(p)
   name = p.split('/').last
   content = File.read(p).delete("\s")
   minified = content.delete("\n")
 
-  warn "Missing copyright headers in #{name}" unless minified.include? copyright_header
+  message("Missing copyright headers", file: name, line: 0) unless minified.include? copyright_header
 
   lines = content.split("\n")
   lines.each_with_index do |line, index|
-    warn "TODO comment left in `#{name}` on line #{index+1}" if line.downcase =~ /\/\/todo/
+    message("TODO comment left", file: name, line: index + 1) if line.downcase =~ /\/\/todo/
   end
 end
 


### PR DESCRIPTION
# What's in this PR?

* The new Danger 3.2.0 supports adding GitHub inline comments, which means we can add line comments if there are any TODOs etc. left. (see https://github.com/danger/danger/blob/master/CHANGELOG.md#320)

