### PR TITLE
Skipping Danger for WIP pull requests

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,7 @@
+# Skip Danger for work-in-progress PRs
+if github.pr_title.include? "WIP:"
+  return
+end
 
 def copyright_header(year = Time.new.year)
   return "////Wire//Copyright(C)#{year}WireSwissGmbH////Thisprogramisfreesoftware:youcanredistributeitand/ormodify//itunderthetermsoftheGNUGeneralPublicLicenseaspublishedby//theFreeSoftwareFoundation,eitherversion3oftheLicense,or//(atyouroption)anylaterversion.////Thisprogramisdistributedinthehopethatitwillbeuseful,//butWITHOUTANYWARRANTY;withouteventheimpliedwarrantyof//MERCHANTABILITYorFITNESSFORAPARTICULARPURPOSE.Seethe//GNUGeneralPublicLicenseformoredetails.////YoushouldhavereceivedacopyoftheGNUGeneralPublicLicense//alongwiththisprogram.Ifnot,seehttp://www.gnu.org/licenses/.//"


### PR DESCRIPTION
If we have a pull request that is often updated (e.g. an integration PR) then Danger comments are not very useful.