### PR TITLE
Uploading code coverage and running Danger

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -57,4 +57,4 @@ end
 
 xcode_summary.ignored_files = 'Pods/**'
 
-xcode_summary.report 'build/xcodebuild.json'
+xcode_summary.report 'build/reports/errors.json'

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -46,7 +46,7 @@ platform :ios do
         sh "chmod +x codecov"
         codecov = "./codecov -J '^#{config.framework}$' -D ../DerivedData -X xcodellvm"
 
-        # This should be present on Jenkins, but not needed when running on CircleCI
+        # When not running on CircleCI we need to supply more parameters to Codecov.io script
         if ENV["CIRCLECI"].nil?
             if ENV["CODECOV_TOKEN"].nil?
                 UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -52,11 +52,11 @@ platform :ios do
             if ENV["CODECOV_TOKEN"].nil?
                 UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"
             end
-            current_branch = sh "git rev-parse --abbrev-ref HEAD"
+            current_branch = sh "git rev-parse --abbrev-ref HEAD".strip()
             if current_branch.nil? || current_branch.empty?
                 UI.user_error! "Cannot figure out current branch!"
             end
-            current_commit = sh "git rev-parse --verify HEAD"
+            current_commit = sh "git rev-parse --verify HEAD".strip()
             if current_commit.nil? || current_commit.empty?
                 UI.user_error! "Cannot figure out current commit!"
             end

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -48,14 +48,19 @@ platform :ios do
 
         # This should be present on Jenkins, but not needed when running on CircleCI
         if ENV["CIRCLECI"].nil?
+
+            if ENV["CODECOV_TOKEN"].nil?
+                UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"
+            end
             current_branch = sh "git rev-parse --abbrev-ref HEAD"
             if current_branch.nil? || current_branch.empty?
                 UI.user_error! "Cannot figure out current branch!"
             end
-            if ENV["CODECOV_TOKEN"].nil?
-                UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"
+            current_commit = sh "git rev-parse --verify HEAD"
+            if current_commit.nil? || current_commit.empty?
+                UI.user_error! "Cannot figure out current commit!"
             end
-            codecov << " -t #{ENV["CODECOV_TOKEN"]} -B #{current_branch}"
+            codecov << " -t #{ENV["CODECOV_TOKEN"]} -B #{current_branch} -C #{current_commit}"
         end
         sh codecov
 

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -36,7 +36,34 @@ platform :ios do
             derived_data_path: "DerivedData"
         )
 
-        trainer(output_directory: "build")
+        trainer(output_directory: "test")
+    end
+
+    desc "Run post-test tasks"
+    lane :post_test do
+        config = Config.read_current()
+        sh "curl -s https://codecov.io/bash > codecov"
+        sh "chmod +x codecov"
+        codecov = "./codecov -J '^#{config.framework}$' -D ../DerivedData -X xcodellvm"
+
+        # This should be present on Jenkins, but not needed when running on CircleCI
+        if ENV["CIRCLECI"].nil?
+            if git_branch.nil?
+                UI.user_error! "Cannot figure out current branch!"
+            end
+            if ENV["CODECOV_TOKEN"].nil?
+                UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"
+            end
+            codecov << " -t #{ENV["CODECOV_TOKEN"]} -B #{git_branch}"
+        end
+        sh codecov
+
+        dependencies_url = ENV.fetch("DEPENDENCIES_BASE_URL") { "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master" }
+        sh "curl -O #{dependencies_url}/Dangerfile"
+        danger(
+            dangerfile: "DangerFile",
+            github_api_token: ENV["GITHUB_ACCESS_TOKEN"]
+        )
     end
 
     desc "Release new framework version. Expects parameter 'type' with 'major', 'minor' or 'patch'"

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -55,7 +55,7 @@ platform :ios do
             if ENV["CODECOV_TOKEN"].nil?
                 UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"
             end
-            codecov << " -t #{ENV["CODECOV_TOKEN"]} -B #{git_branch}"
+            codecov << " -t #{ENV["CODECOV_TOKEN"]} -B #{current_branch}"
         end
         sh codecov
 

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -61,7 +61,7 @@ platform :ios do
         dependencies_url = ENV.fetch("DEPENDENCIES_BASE_URL") { "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master" }
         sh "curl -O #{dependencies_url}/Dangerfile"
         danger(
-            dangerfile: "DangerFile",
+            dangerfile: "Fastlane/Dangerfile",
             github_api_token: ENV["GITHUB_ACCESS_TOKEN"]
         )
     end

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -48,19 +48,18 @@ platform :ios do
 
         # This should be present on Jenkins, but not needed when running on CircleCI
         if ENV["CIRCLECI"].nil?
-
             if ENV["CODECOV_TOKEN"].nil?
                 UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"
             end
-            current_branch = sh "git rev-parse --abbrev-ref HEAD".strip()
+            current_branch = sh "git rev-parse --abbrev-ref HEAD"
             if current_branch.nil? || current_branch.empty?
                 UI.user_error! "Cannot figure out current branch!"
             end
-            current_commit = sh "git rev-parse --verify HEAD".strip()
+            current_commit = sh "git rev-parse --verify HEAD"
             if current_commit.nil? || current_commit.empty?
                 UI.user_error! "Cannot figure out current commit!"
             end
-            codecov << " -t #{ENV["CODECOV_TOKEN"]} -B #{current_branch} -C #{current_commit}"
+            codecov << " -t #{ENV["CODECOV_TOKEN"]} -B #{current_branch.chomp} -C #{current_commit.chomp}"
         end
         sh codecov
 

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -48,7 +48,8 @@ platform :ios do
 
         # This should be present on Jenkins, but not needed when running on CircleCI
         if ENV["CIRCLECI"].nil?
-            if git_branch.nil?
+            current_branch = sh "git rev-parse --abbrev-ref HEAD"
+            if current_branch.nil? || current_branch.empty?
                 UI.user_error! "Cannot figure out current branch!"
             end
             if ENV["CODECOV_TOKEN"].nil?

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
         GITHUB_TOKEN = credentials('github-api-token')
         GITHUB_ACCESS_TOKEN = credentials('github-api-token')
         PATH = "/Users/ci/.rbenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        CODECOV_TOKEN = credentials("codecov-${params.BOT_FRAMEWORK}")
     }
     parameters {
         choice(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
         DEPENDENCIES_BASE_URL = "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/feature/fastlane"
         GITHUB_TOKEN = credentials('github-api-token')
         GITHUB_ACCESS_TOKEN = credentials('github-api-token')
+        PATH = "/Users/ci/.rbenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
     }
     parameters {
         choice(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,15 +58,6 @@ pipeline {
             steps {
                 sh ''' #!/bin/bash -l
                     bundle exec fastlane test
-                '''
-            }
-        }
-        stage('Post test') {
-            when {
-                expression { params.RUN_TESTS == true }
-            }
-            steps {
-                sh ''' #!/bin/bash -l
                     bundle exec fastlane post_test
                 '''
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,16 @@ pipeline {
                 '''
             }
         }
+        stage('Post test') {
+            when {
+                expression { params.RUN_TESTS == true }
+            }
+            steps {
+                sh ''' #!/bin/bash -l
+                    bundle exec fastlane post_test
+                '''
+            }
+        }
         stage('Release') {
             steps {
                 // This env var gets set from pipeline config branch, so scripts get messed up. We know we are in develop now!


### PR DESCRIPTION
## What's in this PR?

### Build script

The plan is to unify the build scripts and use same steps for testing PRs and making a release.

The last bit missing was to upload code coverage information and run Danger after tests. There are some variables automatically set when running on CircleCI (which repository it is, branch name and commit SHA) that we need to supply manually on Jenkins.

### Jenkins config

Storing Codecov.io token in Jenkins credentials and also overriding PATH so that it would be the same on all nodes.