### PR TITLE
Added test coverage tracking for all classes related to calling

### DIFF
--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -61,7 +61,7 @@ platform :ios do
         end
         sh codecov
 
-        dependencies_url = ENV.fetch("DEPENDENCIES_BASE_URL") { "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master" }
+        dependencies_url = ENV.fetch("DEPENDENCIES_BASE_URL") { "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/feature/calling-tracking" }
         sh "curl -O #{dependencies_url}/Dangerfile"
         danger(
             dangerfile: "Fastlane/Dangerfile",

--- a/Fastlane/Frameworks
+++ b/Fastlane/Frameworks
@@ -61,7 +61,7 @@ platform :ios do
         end
         sh codecov
 
-        dependencies_url = ENV.fetch("DEPENDENCIES_BASE_URL") { "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/feature/calling-tracking" }
+        dependencies_url = ENV.fetch("DEPENDENCIES_BASE_URL") { "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master" }
         sh "curl -O #{dependencies_url}/Dangerfile"
         danger(
             dangerfile: "Fastlane/Dangerfile",


### PR DESCRIPTION
Danger now prints out test coverage percentages for files that have `calling` in their name/path. This shows an approximate state of calling code testing.