### PR TITLE
Retry failed tests

### DIFF
--- a/Azure/build-and-test/Fastfile
+++ b/Azure/build-and-test/Fastfile
@@ -33,8 +33,22 @@ platform :ios do
             derived_data_path: "DerivedData",
             buildlog_path: "test",
             output_directory: "test",
-            output_types: "junit"
+            output_types: "junit",
+            fail_build: false
         )
+        to_retry = failing_testsuites("../test/report.junit")
+
+        unless to_retry.length == 0
+            UI.important "Some tests failed, retrying to see if they will pass"
+            scan(
+                test_without_building: true,
+                devices: ["iPhone 7"],
+                code_coverage: false,
+                derived_data_path: "DerivedData",
+                only_testing: to_retry,
+                fail_build: true
+            )
+        end
     end
 
     desc "Run post-test tasks"
@@ -61,6 +75,35 @@ platform :ios do
         sh codecov
     end
 end 
+
+# Return an array of test classes that have failures from junit file
+def failing_testsuites(junit)
+    testsuites = []
+    testsuite = ""
+
+    File.foreach(junit) do |line|
+        # Should match WireSyncEngine-iOS-Tests in <testsuites name='WireSyncEngine-iOS-Tests.xctest' tests='23' failures='1'>
+        testsuite_match = line.match /^\s*<testsuites name='(?<testsuite>.+)\.xctest/
+        if !testsuite_match.nil? && testsuite_match.captures.count == 1 && !testsuite_match[:testsuite].nil?
+            testsuite = testsuite_match[:testsuite]
+        end
+
+        # Should match 
+        #   AccountStatusTests and 1 in <testsuite name='WireSyncEngine_iOS_Tests.AccountStatusTests' tests='6' failures='1'>
+        #   AND
+        #   ZMDefinesTest and 1 in <testsuite name='ZMDefinesTest' tests='12' failures='1'>
+
+        testcase_match = line.match /^\s*<testsuite name='(.+\.)*(?<testclass>.+)' tests='\d+' failures='(?<failures>\d+)'/
+        if !testcase_match.nil? && testcase_match.captures.count == 2 && Integer(testcase_match[:failures]) > 0
+            testclass = testcase_match[:testclass]
+            result = "#{testsuite}/#{testclass}"
+            testsuites.push(result)  
+        end
+
+    end
+
+    return testsuites
+end
 
 class Config
 

--- a/Azure/framework-pipelines.yml
+++ b/Azure/framework-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
     steps:
     - template: build-and-test/build-and-test.yml
       parameters:
-        branch: feature/rerun-tests
+        branch: master
   - job: Release
     pool:
       vmImage: "macOS 10.13"

--- a/Azure/framework-pipelines.yml
+++ b/Azure/framework-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
     steps:
     - template: build-and-test/build-and-test.yml
       parameters:
-        branch: master
+        branch: feature/rerun-tests
   - job: Release
     pool:
       vmImage: "macOS 10.13"


### PR DESCRIPTION
Sometimes when testing PRs the testsuite fails because we have unreliable/flaky tests. We should of course fix them in the long run, but most of the time we just retry the job. This however takes a lot of time because we rebuild the project and run the full test suite.

This PR adds another step when testing:
1. Run full test suite, but do not fail build if any tests fail
1. Parse the test results from `test/report.junit`.
2. Look for test classes that have failing tests.
3. Rerun only those tests.
4. Fail if they do not pass successfully.

### Note 

The `junit` file is a simple XML that is generated by Fastlane. It has quite simple and regular structure so it should be fine to use regexps for parsing lines that we are interested in.

Fixes https://github.com/wireapp/ios-architecture/issues/61