### PR TITLE
Preformance improvement - Test & QA: build for simulator in parallel

### DIFF
--- a/Jenkins/UI/Build.groovy
+++ b/Jenkins/UI/Build.groovy
@@ -110,18 +110,22 @@ pipeline {
                 """
             }
         }
-        stage('Test') {
-            steps {
-                sh """#!/bin/bash -l
-                    bundle exec fastlane test xcode_version:${xcode_version}
-                """
-            }
-        }
-        stage("QA: build for simulator") {
-            steps {
-                sh """#!/bin/bash -l
-                    bundle exec fastlane build_for_release build_number:${BUILD_NUMBER} build_type:${BUILD_TYPE} configuration:Debug for_simulator:true xcode_version:${xcode_version}
-                """
+        stage('Test & QA: build for simulator') {
+            parallel {
+                stage('Test') {
+                    steps {
+                        sh """#!/bin/bash -l
+                            bundle exec fastlane test xcode_version:${xcode_version}
+                        """
+                    }
+                }
+                stage("QA: build for simulator") {
+                    steps {
+                        sh """#!/bin/bash -l
+                            bundle exec fastlane build_for_release build_number:${BUILD_NUMBER} build_type:${BUILD_TYPE} configuration:Debug for_simulator:true xcode_version:${xcode_version}
+                        """
+                    }
+                }
             }
         }
         stage("QA: build for device") {


### PR DESCRIPTION
`QA: build for simulator` stage actually is a zipping task and do not affect to `Test` stage.
This PR put these steps in parallel. (`Test` step is about 3 min and `QA: build for simulator` is about 40 sec. After this improvement, both of them can be done in about 3 min and save the time for `QA: build for simulator`)