### PR TITLE
Feature: create release in XCFramework format

### DIFF
--- a/Azure/build-and-test/build-and-test.yml
+++ b/Azure/build-and-test/build-and-test.yml
@@ -14,7 +14,7 @@ steps:
 - script: |
     sudo xcode-select -switch /Applications/Xcode_12.4.app
     echo "⚠️  Using patched Carthage script for Xcode12"
-    bash ./wire-ios-shared-resources/Azure/build-and-test/carthageXcode12.sh bootstrap --platform iOS --new-resolver
+    bash ./wire-ios-shared-resources/Azure/build-and-test/carthageXcode12.sh bootstrap --platform iOS --new-resolver --use-xcframeworks
   env:
     GITHUB_ACCESS_TOKEN: $(GITHUB_ACCESS_TOKEN)   
   displayName: "Setup environment"

--- a/Azure/release-framework/Fastfile
+++ b/Azure/release-framework/Fastfile
@@ -24,18 +24,10 @@ platform :ios do
     
         sh "rm -f ../#{carthage_config.archive_name} || true"
         sh "rm -rf ../#{carthage_config.build_result} || true"
-        carthage(
-            command: "build",
-            no_skip_current: true,
-            platform: "iOS"
-        )
-        # Swift frameworks need to be removed or Apple will reject the app
-        sh "rm -rf ../#{carthage_config.build_result}/Frameworks"
-        carthage(
-            command: "archive",
-            frameworks: [carthage_config.framework],
-            output: carthage_config.archive_name,
-        )
+                
+        sh "xcodebuild archive -project ../#{carthage_config.framework}.xcodeproj -scheme #{carthage_config.framework} -configuration Release -destination 'generic/platform=iOS' -archivePath './#{carthage_config.framework}.framework-iphoneos.xcarchive' SKIP_INSTALL=NO  BUILD_LIBRARY_FOR_DISTRIBUTION=YES"
+        sh "xcodebuild archive -project ../#{carthage_config.framework}.xcodeproj -scheme #{carthage_config.framework} -configuration Release -destination 'generic/platform=iOS Simulator' -archivePath './#{carthage_config.framework}.framework-iphonesimulator.xcarchive' SKIP_INSTALL=NO  BUILD_LIBRARY_FOR_DISTRIBUTION=YES"
+        sh "xcodebuild -create-xcframework -framework './#{carthage_config.framework}.framework-iphoneos.xcarchive/Products/Library/Frameworks/WireSystem.framework' -framework './#{carthage_config.framework}.framework-iphonesimulator.xcarchive/Products/Library/Frameworks/#{carthage_config.framework}.framework' -output '../#{carthage_config.framework}.xcframework'"
 
         previous_version = sh("git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1`").chomp
         message = release_details(previous_version, version, config)
@@ -47,7 +39,7 @@ platform :ios do
             tag_name: version,
             description: message,
             commitish: "develop",
-            upload_assets: [carthage_config.archive_name]
+            upload_assets: ["#{carthage_config.framework}.xcframework"]
         )
     end
 


### PR DESCRIPTION
Create framework release in `XCFramework` format instead of universal bundle.
This PR should not be merged before fully tested on `billypchan` fork, and got approval from the iOS team.