### PR TITLE
feature: try catch release build and rebuild without symbol

### DIFF
--- a/Jenkins/UI/BuildAppStore.groovy
+++ b/Jenkins/UI/BuildAppStore.groovy
@@ -85,9 +85,18 @@ pipeline {
         }
         stage('Build for AppStore') {
             steps {
-                sh """#!/bin/bash -l
-                    bundle exec fastlane build_for_release build_number:${BUILD_NUMBER} build_type:${BUILD_TYPE} xcode_version:${xcode_version}
-                """
+                script {
+                    try {
+                        sh """#!/bin/bash -l
+                            bundle exec fastlane build_for_release build_number:${BUILD_NUMBER} build_type:${BUILD_TYPE} xcode_version:${xcode_version}
+                        """
+                    } catch (Exception e) {
+                        echo 'Exception occurred: ' + e.toString()  + 'retry build without symbols'
+                        sh """#!/bin/bash -l
+                            bundle exec fastlane build_for_release_without_symbols build_number:${BUILD_NUMBER} build_type:${BUILD_TYPE} xcode_version:${xcode_version}
+                        """
+                    }
+                }
             }
         }
         stage("Upload results") {


### PR DESCRIPTION
Due to the missing symbol in framework issue, the build for release step in App Store build pipeline may fail. This PR added try catch in the stage. When error is catch, build again without symbols.