### PR TITLE
do not allow test concurrently

### DIFF
--- a/Jenkins/UI/Build.groovy
+++ b/Jenkins/UI/Build.groovy
@@ -151,6 +151,7 @@ pipeline {
             }
         }
 
+        options { disableConcurrentBuilds() }
         stage('Test') {
             steps {
                 sh """#!/bin/bash -l


### PR DESCRIPTION
Test enable concurrent build pipeline, but lock test step with `disableConcurrentBuilds`