### PR TITLE
fix: undo retry failed tests SQPIT-799

### DIFF
--- a/Azure/build-and-test/Fastfile
+++ b/Azure/build-and-test/Fastfile
@@ -34,21 +34,8 @@ platform :ios do
             buildlog_path: "test",
             output_directory: "test",
             output_types: "junit",
-            fail_build: false
+            fail_build: true
         )
-        to_retry = failing_testsuites("../test/report.junit")
-
-        unless to_retry.length == 0
-            UI.important "Some tests failed, retrying to see if they will pass"
-            scan(
-                test_without_building: true,
-                devices: ["iPhone 8"],
-                code_coverage: false,
-                derived_data_path: "DerivedData",
-                only_testing: to_retry,
-                fail_build: true
-            )
-        end
     end
 
     desc "Run post-test tasks"
@@ -75,35 +62,6 @@ platform :ios do
         sh codecov
     end
 end 
-
-# Return an array of test classes that have failures from junit file
-def failing_testsuites(junit)
-    testsuites = []
-    testsuite = ""
-
-    File.foreach(junit) do |line|
-        # Should match WireSyncEngine-iOS-Tests in <testsuites name='WireSyncEngine-iOS-Tests.xctest' tests='23' failures='1'>
-        testsuite_match = line.match /^\s*<testsuites name='(?<testsuite>.+)\.xctest/
-        if !testsuite_match.nil? && testsuite_match.captures.count == 1 && !testsuite_match[:testsuite].nil?
-            testsuite = testsuite_match[:testsuite]
-        end
-
-        # Should match 
-        #   AccountStatusTests and 1 in <testsuite name='WireSyncEngine_iOS_Tests.AccountStatusTests' tests='6' failures='1'>
-        #   AND
-        #   ZMDefinesTest and 1 in <testsuite name='ZMDefinesTest' tests='12' failures='1'>
-
-        testcase_match = line.match /^\s*<testsuite name='(.+\.)*(?<testclass>.+)' tests='\d+' failures='(?<failures>\d+)'/
-        if !testcase_match.nil? && testcase_match.captures.count == 2 && Integer(testcase_match[:failures]) > 0
-            testclass = testcase_match[:testclass]
-            result = "#{testsuite}/#{testclass}"
-            testsuites.push(result)  
-        end
-
-    end
-
-    return testsuites
-end
 
 class Config
 

--- a/Azure/build-and-test/Fastfile
+++ b/Azure/build-and-test/Fastfile
@@ -34,7 +34,8 @@ platform :ios do
             buildlog_path: "test",
             output_directory: "test",
             output_types: "junit",
-            fail_build: true
+            fail_build: true,
+            number_of_retries: 1
         )
     end
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQPIT-799" title="SQPIT-799" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10818&avatarType=issuetype" />SQPIT-799</a>  fix: flaky test on wire-ios
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When tests crashed or failed, the test suit result still mark as passed.

### Causes (Optional)

We added a retry test logic:
https://github.com/wireapp/wire-ios-shared-resources/pull/28

But this logic can not capture when some test crashed or failed in some cases, e.g. 
https://github.com/wireapp/wire-ios-sync-engine/pull/1614

### Solutions

Undo the retry test logic, if we find any flaky test, use XCT expected fail or XCT skip for expect condition.
set `number_of_retries` to 1 to retry after fail