### PR TITLE
fix: set release framework xcode app

### DIFF
--- a/Azure/framework-pipelines.yml
+++ b/Azure/framework-pipelines.yml
@@ -24,3 +24,4 @@ jobs:
     - template: release-framework/release-framework.yml
       parameters:
         branch: master
+        xcodeAppName: ${{ parameters.xcodeAppName }}

--- a/Azure/release-framework/release-framework.yml
+++ b/Azure/release-framework/release-framework.yml
@@ -1,12 +1,20 @@
 parameters:
-  branch: "master"
+  - name: branch
+    type: string
+    default: "master"
+  - name: xcodeAppName
+    type: string
+    default: "Xcode_13.1"
+    values:
+    - "Xcode_13.1"
+    - "Xcode_12.4"
 
 steps:
 - script: |
     git clone --single-branch -b $BRANCH https://github.com/wireapp/wire-ios-shared-resources.git
     mkdir -p fastlane
     cp wire-ios-shared-resources/Azure/release-framework/Fastfile fastlane/Fastfile
-    sudo xcode-select -switch /Applications/Xcode_13.1.app
+    sudo xcode-select -switch /Applications/${{ parameters.xcodeAppName }}.app
     carthage bootstrap --use-xcframeworks
   env:
     GITHUB_ACCESS_TOKEN: $(GITHUB_ACCESS_TOKEN)   


### PR DESCRIPTION
# What's new in this PR?

follow up of https://github.com/wireapp/wire-ios-shared-resources/pull/70. Add parameters to allow selection Xcode 12 or 13 when release a framework.