### PR TITLE
chore: enable test artifact upload IC-31

### DIFF
--- a/Azure/build-and-test/build-and-test.yml
+++ b/Azure/build-and-test/build-and-test.yml
@@ -54,18 +54,18 @@ steps:
   condition: succeededOrFailed()
   displayName: "Store test log"
 
-#- script: |
-#    cd DerivedData/Logs/Test
-#    zip -r ../../../tests.xcresult.zip *.xcresult
-#  displayName: "Compress .xcresult"
-#  condition: succeededOrFailed()
+- script: |
+    cd DerivedData/Logs/Test
+    zip -r ../../../tests.xcresult.zip *.xcresult
+  displayName: "Compress .xcresult"
+  condition: succeededOrFailed()
 
-#- task: PublishBuildArtifacts@1
-#  inputs:
-#    pathtoPublish: "tests.xcresult.zip"
-#    artifactName: "Test logs bundle (.xcresult)"
-#  condition: succeededOrFailed()
-#  displayName: "Store test logs bundle (.xcresult)"
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: "tests.xcresult.zip"
+    artifactName: "Test logs bundle (.xcresult)"
+  condition: succeededOrFailed()
+  displayName: "Store test logs bundle (.xcresult)"
 
 - script: |
     fastlane post_test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/IC-31" title="IC-31" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />IC-31</a>  Re-enable test artefacts uploading to Azure
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This reverts commit 914c33aea92f63537bc3aaa30f78a9cf0b910b7c.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR re-enables the steps to upload the test results to azure. They were disabled previously because they were failing for an unknown reason, but it appears that this is no longer the case.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
