### PR TITLE
fix: client-ios-build-appstore-pipeline parameters

### DIFF
--- a/Jenkins/UI/BuildAppStore.groovy
+++ b/Jenkins/UI/BuildAppStore.groovy
@@ -37,12 +37,17 @@ pipeline {
     parameters {
         string(defaultValue: "develop", description: 'Branch to use', name: 'branch_to_build')
         string(defaultValue: "", description: 'Override build number with', name: 'build_number_override')
+        choice(
+            choices: ["12.4", "13.1"],
+            description: 'XCode version',
+            name: "xcode_version"
+        )
     }
 
     stages {
         stage('Checkout') {
             steps {
-                // Let's check if we are overriding the app build number 
+                // Let's check if we are overriding the app build number
                 script {
                     if ("${build_number_override}" != '') {
                         BUILD_NUMBER = "${build_number_override}"
@@ -132,4 +137,3 @@ pipeline {
         }
     }
 }
-


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Running the `client-ios-build-appstore-pipeline` via the Jenkins web interface fails

### Causes (Optional)

The `xcode_version` parameter is missing 

### Solutions

Add a choice parameter for the `xcode_version` to the pipeline

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
