### PR TITLE
chore: add more people to merge pr command

### DIFF
--- a/.github/workflows/mergePR.yml
+++ b/.github/workflows/mergePR.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.commitPAT }}
-      ADMINS: ('marcoconti83' 'typfel' 'johnxnguyen' 'David-Henner' 'KaterinaWire' 'agisilaos')
+      ADMINS: ('marcoconti83' 'typfel' 'johnxnguyen' 'David-Henner' 'KaterinaWire' 'agisilaos', 'netbe', 'johnranj', 'tmspzz')
       COMMENT_BODY: ${{ github.event.comment.body }}
     steps:
     


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some devs can't release frameworks.

### Causes

They're not on the admin list.

### Solutions

Add them.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
