### PR TITLE
chore: skip build RC public to testflight when merge on frida branch

### DIFF
--- a/Jenkins/UI/AppStoreMono.groovy
+++ b/Jenkins/UI/AppStoreMono.groovy
@@ -39,6 +39,11 @@ pipeline {
             }
         }
         stage ("Trigger build") {
+            when {
+                expression {
+                    return env.BRANCH_NAME != 'release/frida';
+                }
+            }
             steps {
                 build(
                     job: 'wire-ios-mono-build', 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When merging into `release/frida` branch the public release is triggered and mix the Public RC builds and Frida RC builds on AppStore connect.

This skips the trigger for this branch.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
