### PR TITLE
fix: wrong branch environment variable

### DIFF
--- a/Jenkins/UI/AppStoreMono.groovy
+++ b/Jenkins/UI/AppStoreMono.groovy
@@ -41,7 +41,7 @@ pipeline {
         stage ("Trigger build") {
             when {
                 expression {
-                    return env.BRANCH_NAME != 'release/frida';
+                    return BRANCH != 'release/frida';
                 }
             }
             steps {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

AppStore release job is still triggering by `release/frida`.


### Notes

The build [#5543] was indeed skipped thanks to this change

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
