### PR TITLE
fix: default xcode version 14.2

### DIFF
--- a/Jenkins/UI/AppStoreMono.groovy
+++ b/Jenkins/UI/AppStoreMono.groovy
@@ -11,7 +11,7 @@ pipeline {
     }
     parameters {
         choice(
-            choices: ["13.2.1", "14.2", "14.3"],
+            choices: ["14.2", "14.3"],
             description: 'Xcode version to build with.',
             name: "xcode_version"
         )
@@ -22,7 +22,7 @@ pipeline {
                 script {
                     def scmVars = checkout([
                         $class: 'GitSCM',
-                        branches: [[name: "origin/release/**"]],
+                        branches: [[name: "origin/release/cycle-**"]],
                         extensions: [
                             [$class: 'AuthorInChangelog'],
                             [$class: 'CloneOption', depth: 0, honorRefspec: true, noTags: true, reference: ''],

--- a/Jenkins/UI/Beta.groovy
+++ b/Jenkins/UI/Beta.groovy
@@ -56,7 +56,7 @@ pipeline {
             name: 'last_commit_for_changelog'
         )
         choice(
-            choices: ["13.2.1", "14.2", "14.3"],
+            choices: ["14.2", "14.3"],
             description: 'Xcode version to build with.',
             name: "xcode_version"
         )

--- a/Jenkins/UI/BuildAppStore.groovy
+++ b/Jenkins/UI/BuildAppStore.groovy
@@ -40,7 +40,7 @@ pipeline {
         string(defaultValue: "develop", description: 'Branch to use', name: 'branch_to_build')
         string(defaultValue: "", description: 'Override build number with', name: 'build_number_override')
         choice(
-            choices: ["13.2.1", "14.2", "14.3"],
+            choices: ["14.2", "14.3"],
             description: 'Xcode version',
             name: "xcode_version"
         )

--- a/Jenkins/UI/BuildAppStoreMono.groovy
+++ b/Jenkins/UI/BuildAppStoreMono.groovy
@@ -49,7 +49,7 @@ pipeline {
             name: 'build_number_override'
         )
         choice(
-            choices: ["13.2.1", "14.3"],
+            choices: ["14.2", "14.3"],
             description: 'Xcode version to build with.',
             name: "xcode_version"
         )

--- a/Jenkins/UI/DevelopMono.groovy
+++ b/Jenkins/UI/DevelopMono.groovy
@@ -12,7 +12,7 @@ pipeline {
     }
     parameters {
         choice(
-            choices: ["13.2.1", "14.2", "14.3"],
+            choices: ["14.2", "14.3"],
             description: 'Xcode version to build with.',
             name: "xcode_version"
         )


### PR DESCRIPTION


----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Pipelines with SCM trigger will default to Xcode 13.2.1

### Solutions

* Remove 13.2.1 option and set 14.2 as first choice
* Set trigger on release/cycle-XXX for public Appstore to avoid bk build to trigger the job

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
